### PR TITLE
Forcing updates on drifting resources

### DIFF
--- a/databricks-kube/src/main.rs
+++ b/databricks-kube/src/main.rs
@@ -80,7 +80,6 @@ async fn main() -> Result<(), DatabricksKubeError> {
 
     let api_secret_name =
         get_store_key(latest_config(configmap_store.clone()), "api_secret_name").unwrap();
-
     ensure_api_secret(api_secret_name.clone(), secret_api.clone()).await?;
     let api_secret_store = watch_api_secret(api_secret_name.clone(), secret_api).await?;
 
@@ -90,7 +89,6 @@ async fn main() -> Result<(), DatabricksKubeError> {
     let job_ingest = DatabricksJob::ingest_task(ctx.clone());
 
     let git_credential_controller = GitCredential::controller(ctx.clone());
-    let git_credential_ingest = GitCredential::ingest_task(ctx.clone());
 
     let repo_controller = Repo::controller(ctx.clone());
     let repo_ingest = Repo::ingest_task(ctx.clone());
@@ -118,10 +116,6 @@ async fn main() -> Result<(), DatabricksKubeError> {
                         res
                     })
             },
-        )
-        .start(
-            "git_credential_ingest",
-            |_: SubsystemHandle<DatabricksKubeError>| git_credential_ingest,
         )
         .start(
             "repo_controller",

--- a/databricks-kube/src/traits/synced_api_resource.rs
+++ b/databricks-kube/src/traits/synced_api_resource.rs
@@ -243,6 +243,7 @@ where
     let latest_remote = latest_remote?;
     let kube_as_api: TAPIType = resource.as_ref().clone().into();
 
+    /*
     let latest_remote_api_type: Box<TAPIType> = Box::new(latest_remote.clone());
 
      //If there is a drift, make sure dbrix api is updated
@@ -255,6 +256,7 @@ where
             .unwrap()?;
         log::info!("Resource updated");
     }
+    */
 
     // If resource in sync, spawn a task to watch for deletion events
     if (owner == "operator")
@@ -283,6 +285,15 @@ where
             )
             .unwrap_err()
         );
+        if (owner == "operator") {
+            log::info!("Remote drifted. Updating");
+            let updated = resource
+                .remote_update(context.clone())
+                .next()
+                .await
+                .unwrap()?;
+            log::info!("Resource updated");
+        }
     }
         
     // Push to API if operator owned, or let user know


### PR DESCRIPTION
Starting off for now to get some initial feedback because I think I finally have a hang on this operator after struggling for a bit. 

Trying out a potentially different way to find diffs in kube resources