### PR TITLE
Remove ingest behavior, better controller behavior, use finalizers for cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "databricks_kube"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "assert-json-diff",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ metadata:
     databricks-operator/owner: operator
 ```
 
-By default, databricks-kube-operator will also sync existing API resources from Databricks into Kubernetes (goal: surface status). Resources owned by the API are tagged as such with an annotation on ingest:
+It is also possible to set a resource's owner to `api`, which will update the Kubernetes resource as it changes on Databricks. 
 
 ```yaml
 apiVersion: com.dstancu.databricks/v1
@@ -85,7 +85,6 @@ kind: DatabricksJob
 metadata:
   annotations:
     databricks-operator/owner: api
-  creationTimestamp: "2022-11-04T21:46:12Z"
   generation: 1
   name: hello-world
   ...

--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/databricks-kube-operator/templates/sts.yaml
+++ b/charts/databricks-kube-operator/templates/sts.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: dko
-        image: ghcr.io/mach-kernel/databricks-kube-operator:0.2.3
+        image: ghcr.io/mach-kernel/databricks-kube-operator:0.3.0
         imagePullPolicy: Always
         env:
           - name: DATABRICKS_KUBE_CONFIGMAP

--- a/databricks-kube/Cargo.toml
+++ b/databricks-kube/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/crdgen.rs"
 [package]
 name = "databricks_kube"
 default-run = "databricks_kube"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/databricks-kube/src/context.rs
+++ b/databricks-kube/src/context.rs
@@ -1,16 +1,10 @@
 use std::{collections::BTreeMap, env, sync::Arc};
 
-use crate::error::DatabricksKubeError;
-
-use flurry::HashMap;
-
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::{runtime::reflector::Store, Client};
 use lazy_static::lazy_static;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use tokio::task::JoinHandle;
 
 lazy_static! {
     pub static ref CONFIGMAP_NAME: String =
@@ -21,7 +15,6 @@ lazy_static! {
 #[derive(Clone)]
 pub struct Context {
     pub client: Client,
-    pub delete_watchers: Arc<HashMap<String, Box<JoinHandle<Result<(), DatabricksKubeError>>>>>,
     configmap_store: Arc<Store<ConfigMap>>,
     api_secret_store: Arc<Store<Secret>>,
 }
@@ -72,7 +65,6 @@ impl Context {
             api_secret_store,
             client,
             configmap_store,
-            delete_watchers: HashMap::new().into(),
         }
         .into()
     }

--- a/databricks-kube/src/main.rs
+++ b/databricks-kube/src/main.rs
@@ -93,7 +93,6 @@ async fn main() -> Result<(), DatabricksKubeError> {
 
     let job_controller = DatabricksJob::controller(ctx.clone());
     let job_status_controller = DatabricksJob::status_controller(ctx.clone());
-    let job_ingest = DatabricksJob::ingest_task(ctx.clone());
 
     let git_credential_controller = GitCredential::controller(ctx.clone());
     let repo_controller = Repo::controller(ctx.clone());
@@ -119,9 +118,6 @@ async fn main() -> Result<(), DatabricksKubeError> {
                     })
             },
         )
-        .start("job_ingest", |_: SubsystemHandle<DatabricksKubeError>| {
-            job_ingest
-        })
         .start(
             "git_credential_controller",
             |_: SubsystemHandle<DatabricksKubeError>| {

--- a/databricks-kube/src/main.rs
+++ b/databricks-kube/src/main.rs
@@ -57,7 +57,7 @@ async fn log_controller_event<TCRDType>(
 {
     match event {
         Ok((object, _)) => log::info!("{} reconciled", object.name),
-        Err(e) => log::error!("{}", e),
+        Err(e) => log::error!("{:?}", e),
     }
 }
 

--- a/databricks-kube/src/traits/remote_api_resource.rs
+++ b/databricks-kube/src/traits/remote_api_resource.rs
@@ -82,6 +82,8 @@ where
             TCRDType::api_resource().kind,
             resource.name_unchecked()
         );
+
+        return Ok(Action::requeue(Duration::from_secs(300)));
     }
 
     let latest_remote = latest_remote?;

--- a/databricks-kube/src/traits/remote_api_resource.rs
+++ b/databricks-kube/src/traits/remote_api_resource.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, hash::Hash, pin::Pin, sync::Arc, time::Duration};
 
-use crate::{context::Context, error::DatabricksKubeError, util::default_error_policy};
+use crate::{context::Context, error::DatabricksKubeError};
 
 use assert_json_diff::assert_json_matches_no_panic;
 use futures::{Future, FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
@@ -10,158 +10,14 @@ use k8s_openapi::{DeepMerge, NamespaceResourceScope};
 use kube::{
     api::ListParams,
     api::PostParams,
-    runtime::{controller::Action, reflector::ObjectRef, watcher, watcher::Event, Controller},
+    runtime::{controller::Action, finalizer, finalizer::Event, reflector::ObjectRef, Controller},
     Api, CustomResourceExt, Resource, ResourceExt,
 };
 
 use serde::{de::DeserializeOwned, Serialize};
-use tokio::{task::JoinHandle, time::interval};
-
-/// Generic sync task for pushing remote API resources into K8S
-/// TAPIType is OpenAPI generated
-/// TCRDType is the operator's wrapper
-#[allow(dead_code)]
-pub async fn ingest_task<TAPIType, TCRDType>(
-    interval_period: Duration,
-    context: Arc<Context>,
-) -> Result<(), DatabricksKubeError>
-where
-    TCRDType: From<TAPIType>,
-    TCRDType: Resource<Scope = NamespaceResourceScope> + ResourceExt + CustomResourceExt,
-    TCRDType::DynamicType: Default + Eq + Hash,
-    TCRDType: RemoteAPIResource<TAPIType>,
-    TCRDType: Send,
-    TCRDType: Serialize,
-    TCRDType: Sync,
-    TCRDType: Default,
-    TCRDType: Clone,
-    TCRDType: CustomResourceExt,
-    TCRDType: Debug,
-    TCRDType: DeserializeOwned,
-    TCRDType: RemoteAPIResource<TAPIType>,
-    TCRDType: 'static,
-    TAPIType: Send,
-    TAPIType: 'static,
-{
-    let mut duration = interval(interval_period);
-    let kube_api = Api::<TCRDType>::default_namespaced(context.client.clone());
-
-    loop {
-        duration.tick().await;
-
-        log::info!(
-            "Looking for uningested {}(s)",
-            TCRDType::api_resource().kind
-        );
-
-        let mut resource_stream = TCRDType::remote_list_all(context.clone());
-
-        while let Ok(Some(api_resource)) = resource_stream.try_next().await {
-            let mut resource_as_kube: TCRDType = api_resource.into();
-            let name = resource_as_kube.name_unchecked();
-            let kube_resource = kube_api.get(&name).await;
-
-            if kube_resource.is_err() {
-                log::info!(
-                    "{} missing, creating {}",
-                    TCRDType::api_resource().kind,
-                    name
-                );
-            }
-
-            resource_as_kube
-                .annotations_mut()
-                .insert("databricks-operator/owner".to_string(), "api".to_string());
-
-            if let Ok(ref new_kube_resource) = kube_api
-                .create(&PostParams::default(), &resource_as_kube)
-                .await
-            {
-                log::info!(
-                    "Created {} {}",
-                    TCRDType::api_resource().kind,
-                    new_kube_resource.name_unchecked(),
-                );
-            }
-        }
-        log::info!("{} ingest complete", TCRDType::api_resource().kind);
-    }
-}
 
 #[allow(dead_code)]
-pub async fn spawn_delete_watcher<TAPIType, TCRDType>(
-    resource: Arc<TCRDType>,
-    context: Arc<Context>,
-) -> JoinHandle<Result<(), DatabricksKubeError>>
-where
-    TCRDType: From<TAPIType>,
-    TCRDType: Resource<Scope = NamespaceResourceScope> + ResourceExt + CustomResourceExt,
-    TCRDType::DynamicType: Default + Eq + Hash,
-    TCRDType: RemoteAPIResource<TAPIType>,
-    TCRDType: Send,
-    TCRDType: Serialize,
-    TCRDType: Sync,
-    TCRDType: Default,
-    TCRDType: Clone,
-    TCRDType: CustomResourceExt,
-    TCRDType: Debug,
-    TCRDType: DeserializeOwned,
-    TCRDType: 'static,
-    TAPIType: Send,
-    TAPIType: 'static,
-{
-    let kube_api = Api::<TCRDType>::default_namespaced(context.client.clone());
-
-    let params = ListParams {
-        field_selector: Some(format!("metadata.name={}", resource.name_unchecked())),
-        ..ListParams::default()
-    };
-
-    tokio::spawn(async move {
-        let mut watcher = watcher::watcher(kube_api, params).boxed();
-
-        while let Some(event) = watcher
-            .try_next()
-            .map_err(|_e| DatabricksKubeError::ConfigMapMissingError)
-            .await?
-        {
-            if let Event::Deleted(r) = event {
-                let owner = r
-                    .annotations()
-                    .get("databricks-operator/owner")
-                    .map(Clone::clone)
-                    .unwrap_or("operator".to_string());
-
-                if owner == "operator" {
-                    log::info!(
-                        "Removing {} {} from Databricks",
-                        TCRDType::api_resource().kind,
-                        resource.name_unchecked()
-                    );
-
-                    resource.remote_delete(context.clone()).next().await;
-
-                    log::info!(
-                        "Removed {} {} from Databricks",
-                        TCRDType::api_resource().kind,
-                        resource.name_unchecked()
-                    );
-                }
-
-                let watchers = context.delete_watchers.pin();
-                let handle = &**watchers.remove(&resource.self_url_unchecked()).unwrap();
-                handle.abort();
-
-                return Ok(());
-            }
-        }
-
-        Ok(())
-    })
-}
-
-#[allow(dead_code)]
-async fn reconcile<TAPIType, TCRDType>(
+async fn reconcile_apply<TAPIType, TCRDType>(
     resource: Arc<TCRDType>,
     context: Arc<Context>,
 ) -> Result<Action, DatabricksKubeError>
@@ -226,28 +82,10 @@ where
             TCRDType::api_resource().kind,
             resource.name_unchecked()
         );
-
-        // Reconcile after create to bind things like the delete watcher
-        return Ok(Action::requeue(Duration::from_secs(5)));
     }
 
     let latest_remote = latest_remote?;
     let kube_as_api: TAPIType = resource.as_ref().clone().into();
-
-    // If resource in sync, spawn a task to watch for deletion events
-    if (owner == "operator")
-        && latest_remote == kube_as_api
-        && !context
-            .delete_watchers
-            .pin()
-            .contains_key(&resource.name_unchecked())
-    {
-        let handle = spawn_delete_watcher(resource.clone(), context.clone()).await;
-        context
-            .delete_watchers
-            .pin()
-            .insert(resource.self_url_unchecked(), Box::new(handle));
-    }
 
     if latest_remote != kube_as_api {
         log::info!(
@@ -291,7 +129,7 @@ where
         );
     } else if latest_remote != kube_as_api {
         log::info!(
-            "Resource {} {} is not owned by databricks-kube-operator, updating Kubernetes object.\nIngested resources are databricks-operator/owner: api\nTo push updates to Databricks, ensure databricks-operator/owner: operator by creating your object in Kubernetes first.",
+            "Resource {} {} is not owned by databricks-kube-operator, updating Kubernetes object.\nTo push updates to Databricks, ensure databricks-operator/owner: operator",
             TCRDType::api_resource().kind,
             resource.name_unchecked()
         );
@@ -326,6 +164,98 @@ where
     Ok(Action::requeue(Duration::from_secs(300)))
 }
 
+#[allow(dead_code)]
+async fn reconcile_delete<TAPIType, TCRDType>(
+    resource: Arc<TCRDType>,
+    context: Arc<Context>,
+) -> Result<Action, DatabricksKubeError>
+where
+    TCRDType: From<TAPIType>,
+    TCRDType: Resource<Scope = NamespaceResourceScope> + ResourceExt + CustomResourceExt,
+    TCRDType::DynamicType: Default + Eq + Hash,
+    TCRDType: RemoteAPIResource<TAPIType>,
+    TCRDType: Send,
+    TCRDType: Serialize,
+    TCRDType: Sync,
+    TCRDType: Default,
+    TCRDType: Clone,
+    TCRDType: CustomResourceExt,
+    TCRDType: Debug,
+    TCRDType: DeserializeOwned,
+    TCRDType: 'static,
+    TAPIType: From<TCRDType>,
+    TAPIType: PartialEq,
+    TAPIType: Send,
+    TAPIType: Serialize,
+    TAPIType: 'static,
+{
+    let owner = resource
+        .annotations()
+        .get("databricks-operator/owner")
+        .map(Clone::clone)
+        .unwrap_or("operator".to_string());
+
+    if owner == "operator" {
+        log::info!(
+            "Removing {} {} from Databricks",
+            TCRDType::api_resource().kind,
+            resource.name_unchecked()
+        );
+
+        resource.remote_delete(context.clone()).next().await;
+
+        log::info!(
+            "Removed {} {} from Databricks",
+            TCRDType::api_resource().kind,
+            resource.name_unchecked()
+        );
+    }
+
+    Ok(Action::await_change())
+}
+
+#[allow(dead_code)]
+async fn reconcile<TAPIType, TCRDType>(
+    resource: Arc<TCRDType>,
+    context: Arc<Context>,
+) -> Result<Action, DatabricksKubeError>
+where
+    TCRDType: From<TAPIType>,
+    TCRDType: Resource<Scope = NamespaceResourceScope> + ResourceExt + CustomResourceExt,
+    TCRDType::DynamicType: Default + Eq + Hash,
+    TCRDType: RemoteAPIResource<TAPIType>,
+    TCRDType: Send,
+    TCRDType: Serialize,
+    TCRDType: Sync,
+    TCRDType: Default,
+    TCRDType: Clone,
+    TCRDType: CustomResourceExt,
+    TCRDType: Debug,
+    TCRDType: DeserializeOwned,
+    TCRDType: 'static,
+    TAPIType: From<TCRDType>,
+    TAPIType: PartialEq,
+    TAPIType: Send,
+    TAPIType: Serialize,
+    TAPIType: 'static,
+{
+    let kube_api = Api::<TCRDType>::default_namespaced(context.client.clone());
+
+    finalizer(
+        &kube_api,
+        "databricks-operator/remote_api_resource",
+        resource.clone(),
+        |e| async {
+            match e {
+                Event::Apply(res) => reconcile_apply(res, context.clone()).await,
+                Event::Cleanup(res) => reconcile_delete(res, context.clone()).await,
+            }
+        },
+    )
+    .map_err(|e| e.into())
+    .await
+}
+
 /// Implement this on the macroexpanded CRD type, against the SDK type
 pub trait RemoteAPIResource<TAPIType: 'static> {
     fn controller(
@@ -355,30 +285,21 @@ pub trait RemoteAPIResource<TAPIType: 'static> {
 
         Controller::new(root_kind_api.clone(), ListParams::default())
             .shutdown_on_signal()
-            .run(reconcile, default_error_policy, context.clone())
+            .run(
+                reconcile,
+                |res, err, _ctx| {
+                    log::error!(
+                        "API Sync failed for {} {} (retrying in 30s):\n{}",
+                        Self::api_resource().kind,
+                        res.name_unchecked(),
+                        err,
+                    );
+                    Action::requeue(Duration::from_secs(30))
+                },
+                context.clone(),
+            )
             .map_err(|e| DatabricksKubeError::ControllerError(e.to_string()))
             .boxed()
-    }
-
-    fn ingest_task(
-        context: Arc<Context>,
-    ) -> Pin<Box<dyn futures::Future<Output = Result<(), DatabricksKubeError>> + Send + 'static>>
-    where
-        Self: From<TAPIType>,
-        Self: Resource<Scope = NamespaceResourceScope> + ResourceExt + CustomResourceExt,
-        Self::DynamicType: Default + Eq + Hash,
-        Self: Send,
-        Self: Serialize,
-        Self: Sync,
-        Self: Default,
-        Self: Clone,
-        Self: CustomResourceExt,
-        Self: Debug,
-        Self: DeserializeOwned,
-        Self: 'static,
-        TAPIType: Send,
-    {
-        ingest_task::<TAPIType, Self>(Duration::from_secs(300), context).boxed()
     }
 
     fn self_url_unchecked(&self) -> String

--- a/databricks-kube/src/traits/remote_api_status.rs
+++ b/databricks-kube/src/traits/remote_api_status.rs
@@ -108,7 +108,7 @@ pub trait RemoteAPIStatus<TStatusType: 'static> {
                 reconcile,
                 |res, err, _ctx| {
                     log::error!(
-                        "Status sync failed for {} {} (retrying in 30s):\n{}",
+                        "Status sync failed for {} {}:\n{}",
                         Self::api_resource().kind,
                         res.name_unchecked(),
                         err,

--- a/databricks-kube/src/util.rs
+++ b/databricks-kube/src/util.rs
@@ -19,7 +19,7 @@ use kube::{
         wait::{await_condition, conditions},
         watcher::{self, Event},
     },
-    Api, ResourceExt,
+    Api,
 };
 
 use schemars::schema_for;

--- a/databricks-kube/src/util.rs
+++ b/databricks-kube/src/util.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
 
-use std::hash::Hash;
 use std::{sync::Arc, time::Duration};
 
-use crate::context::Context;
 use crate::context::CONFIGMAP_NAME;
 use crate::context::{DatabricksAPISecret, OperatorConfiguration};
 use crate::error::DatabricksKubeError;
@@ -17,31 +15,16 @@ use k8s_openapi::{
 use kube::{
     api::ListParams,
     runtime::{
-        controller::Action,
         reflector::{self, Store},
         wait::{await_condition, conditions},
         watcher::{self, Event},
     },
-    Api, CustomResourceExt, Resource, ResourceExt,
+    Api, ResourceExt,
 };
 
 use schemars::schema_for;
 use serde_json::json;
 use tokio::time::timeout;
-
-pub fn default_error_policy<T>(obj: Arc<T>, err: &DatabricksKubeError, _ctx: Arc<Context>) -> Action
-where
-    T: Resource + ResourceExt + CustomResourceExt,
-    T::DynamicType: Default + Eq + Hash,
-{
-    log::error!(
-        "Reconciliation failed for {} {} (retrying in 30s):\n{}",
-        T::api_resource().kind,
-        obj.name_unchecked(),
-        err,
-    );
-    Action::requeue(Duration::from_secs(30))
-}
 
 pub async fn watch_api_secret(
     api_secret_name: String,


### PR DESCRIPTION
After collecting some initial feedback from @smcavallo and others who have tried it:
- The ingest task has been removed
  - Some described it as cluttersome
  - The Kube cluster per environment pattern + the operator targeting the same Databricks tenant would be confusing since it would mean that `DatabricksJob` resources with the same name would have different behaviors (presumably, only one Kube instance / environment has `owner: operator`)
    - i.e., writing to `my-qa-job` in kube-qa would cause a write to happen to Databricks, but on `kube-prod` the write would be ignored
  - It is better to only see resources you want to _manage_ with Kubernetes by default
  - You can still manually create a resource with `owner: api` to get the operator to prefer Databricks over Kube state.
- Deletion is now done using the kube-rs finalizer helper instead of a watcher. I should have done this in the first place but didn't look hard enough to see that kube-rs does have a helper. This cleaned up things a lot!
- Status API failures no longer requeue making useless requests (waits for next tick)
- Added a test suite helper to DRY up some of the fixture stuff