### PR TITLE
feat: additional helm chart customizations

### DIFF
--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -1,24 +1,17 @@
 apiVersion: v2
+appVersion: 0.5.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.5.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+home: https://github.com/mach-kernel/databricks-kube-operator
+sources:
+  - https://github.com/mach-kernel/databricks-kube-operator
+
+keywords:
+  - databricks
+  - gitops
+  - kube-rs
+maintainers:
+  - name: mach-kernel
+    url: https://mach-kernel.github.io/databricks-kube-operator/

--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.5.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.5.0
+version: 0.5.1
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/charts/databricks-kube-operator/templates/sts.yaml
+++ b/charts/databricks-kube-operator/templates/sts.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: databricks-kube-operator
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "databricks-kube-operator.name" . }}
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
@@ -11,20 +14,25 @@ spec:
   serviceName: databricks-kube-operator
   template:
     metadata:
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels:
-        app: databricks-kube-operator
+        app: {{ template "databricks-kube-operator.name" . }}
     spec:
       serviceAccountName: databricks-kube-operator
       terminationGracePeriodSeconds: 10
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
       containers:
       - name: dko
-        image: ghcr.io/mach-kernel/databricks-kube-operator:0.5.0
+        image: {{ .Values.image.repository }}:{{default .Chart.AppVersion .Values.image.tag }}
         imagePullPolicy: Always
         env:
           - name: DATABRICKS_KUBE_CONFIGMAP
             value: {{ .Values.configMapName }}
           - name: RUST_LOG
             value: databricks_kube
+      resources:
+        {{- toYaml .Values.resources | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/databricks-kube-operator/values.yaml
+++ b/charts/databricks-kube-operator/values.yaml
@@ -1,2 +1,14 @@
 configMapName: databricks-kube-operator
 installCRDs: true
+
+image:
+  repository: ghcr.io/mach-kernel/databricks-kube-operator
+  # -- Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+podAnnotations: {}
+nodeSelector:
+  kubernetes.io/os: linux
+  kubernetes.io/arch: amd64
+resources: {}
+affinity: {}


### PR DESCRIPTION
Allow additional helm chart customizations
* `appVersion` as defined in `Chart.yaml` is now the default image tag used for the operator image which gets deployed
* allow override of resources, affinity, and annotations

Testing:
`helm template --values=values.yaml .`

```
---
# Source: databricks-kube-operator/templates/sts.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: databricks-kube-operator
  namespace: default
  labels:
    app: databricks-kube-operator
    release: release-name
spec:
  selector:
    matchLabels:
      app: databricks-kube-operator
  replicas: 1
  serviceName: databricks-kube-operator
  template:
    metadata:
      annotations:
        {}
      labels:
        app: databricks-kube-operator
    spec:
      serviceAccountName: databricks-kube-operator
      terminationGracePeriodSeconds: 10
      containers:
      - name: dko
        image: ghcr.io/mach-kernel/databricks-kube-operator:0.5.0
        imagePullPolicy: Always
        env:
          - name: DATABRICKS_KUBE_CONFIGMAP
            value: databricks-kube-operator
          - name: RUST_LOG
            value: databricks_kube
      resources:
          {}
      affinity:
          {}
      nodeSelector:
          kubernetes.io/arch: amd64
          kubernetes.io/os: linux
```

