### PR TITLE
databricks-kube-operator - fix container resources

### DIFF
--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.5.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.5.1
+version: 0.5.2
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/charts/databricks-kube-operator/templates/sts.yaml
+++ b/charts/databricks-kube-operator/templates/sts.yaml
@@ -30,8 +30,8 @@ spec:
             value: {{ .Values.configMapName }}
           - name: RUST_LOG
             value: databricks_kube
-      resources:
-        {{- toYaml .Values.resources | nindent 8 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       nodeSelector:


### PR DESCRIPTION
`resources` should be at the container level