### PR TITLE
Fix resource duplication bug, refactor glue to OpenAPI SDK error structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "databricks_kube"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "assert-json-diff",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -365,7 +365,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -409,10 +409,12 @@ dependencies = [
  "kube",
  "lazy_static",
  "log",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
  "tokio",
  "tokio-graceful-shutdown",
  "tokio-stream",
@@ -1566,18 +1568,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1818,7 +1820,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1881,7 +1883,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1950,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,22 +1986,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.5.1
+appVersion: 0.6.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.5.5
+version: 0.6.0
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/databricks-kube/Cargo.toml
+++ b/databricks-kube/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/crdgen.rs"
 [package]
 name = "databricks_kube"
 default-run = "databricks_kube"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/databricks-kube/Cargo.toml
+++ b/databricks-kube/Cargo.toml
@@ -31,6 +31,11 @@ schemars = { version = "0.8.11", features = ["derive"] }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tokio-graceful-shutdown = "0.11.1"
 tokio-stream = "0.1.11"
+thiserror = "1.0.56"
+
+[dependencies.reqwest]
+version = "^0.11"
+features = ["json", "multipart"]
 
 [dev-dependencies]
 tower-test = "0.4.0"

--- a/databricks-kube/src/crds/databricks_job.rs
+++ b/databricks-kube/src/crds/databricks_job.rs
@@ -34,8 +34,6 @@ pub struct DatabricksJobStatus {
     pub latest_run_state: Option<RunState>,
 }
 
-// TODO: We added `NO_RUNS` to `RunLifeCycleState` because
-// it was the laziest way to surface this, but should probably revisit
 impl Default for DatabricksJobStatus {
     fn default() -> Self {
         Self {
@@ -178,7 +176,7 @@ impl RemoteAPIResource<Job> for DatabricksJob {
     }
 
     #[allow(irrefutable_let_patterns)]
-    fn every_reconcile_owned(
+    fn every_reconcile(
         &self,
         _: Arc<Context>,
     ) -> Pin<Box<dyn Future<Output = Result<(), DatabricksKubeError>> + Send>> {
@@ -193,9 +191,7 @@ impl RemoteAPIResource<Job> for DatabricksJob {
             .spec()
             .job
             .job_id
-            .ok_or(DatabricksKubeError::ControllerError(
-                "Cannot fetch remote resource when job_id is undefined".to_string(),
-            ));
+            .ok_or(DatabricksKubeError::IDUnsetError);
 
         try_stream! {
             let config = Job::get_rest_config(context.clone()).await.unwrap();
@@ -278,9 +274,7 @@ impl RemoteAPIResource<Job> for DatabricksJob {
             .spec()
             .job
             .job_id
-            .ok_or(DatabricksKubeError::ControllerError(
-                "Cannot fetch remote resource when job_id is undefined".to_string(),
-            ));
+            .ok_or(DatabricksKubeError::IDUnsetError);
 
         try_stream! {
             let config = Job::get_rest_config(context.clone()).await.unwrap();
@@ -312,9 +306,7 @@ impl RemoteAPIResource<Job> for DatabricksJob {
             .spec()
             .job
             .job_id
-            .ok_or(DatabricksKubeError::ControllerError(
-                "Cannot fetch remote resource when job_id is undefined".to_string(),
-            ));
+            .ok_or(DatabricksKubeError::IDUnsetError);
 
         try_stream! {
             let config = Job::get_rest_config(context.clone()).await.unwrap();

--- a/databricks-kube/src/crds/git_credential.rs
+++ b/databricks-kube/src/crds/git_credential.rs
@@ -103,8 +103,8 @@ impl RemoteAPIResource<APICredential> for GitCredential {
             self.spec()
                 .credential
                 .credential_id
-                .ok_or(DatabricksKubeError::APIError(
-                    "Remote resource cannot exist".to_string(),
+                .ok_or(DatabricksKubeError::ControllerError(
+                    "Cannot fetch remote resource when credential_id is undefined".to_string(),
                 ));
 
         try_stream! {
@@ -126,7 +126,7 @@ impl RemoteAPIResource<APICredential> for GitCredential {
         try_stream! {
             let config = APICredential::get_rest_config(context.clone()).await.unwrap();
 
-            let secret_name = self.spec().secret_name.clone().ok_or(DatabricksKubeError::SecretMissingError)?;
+            let secret_name = self.spec().secret_name.clone().ok_or(DatabricksKubeError::SecretMissingError("".to_string()))?;
             log::info!("Reading secret {}", secret_name);
 
             let secrets_api = Api::<Secret>::default_namespaced(context.client.clone());
@@ -138,7 +138,7 @@ impl RemoteAPIResource<APICredential> for GitCredential {
                 .flat_map(|m| m.get("personal_access_token").map(Clone::clone))
                 .flat_map(|buf| std::str::from_utf8(&buf.0).ok().map(ToString::to_string))
                 .next()
-                .ok_or(DatabricksKubeError::SecretMissingError)?;
+                .ok_or(DatabricksKubeError::SecretMissingError(secret_name))?;
 
             let new_credential = default_api::create_git_credential(
                 &config,
@@ -168,7 +168,7 @@ impl RemoteAPIResource<APICredential> for GitCredential {
         try_stream! {
             let config = APICredential::get_rest_config(context.clone()).await.unwrap();
 
-            let secret_name = self.spec().secret_name.clone().ok_or(DatabricksKubeError::SecretMissingError)?;
+            let secret_name = self.spec().secret_name.clone().ok_or(DatabricksKubeError::SecretMissingError("".to_string()))?;
             log::info!("Reading secret {}", secret_name);
 
             let secrets_api = Api::<Secret>::default_namespaced(context.client.clone());
@@ -180,7 +180,7 @@ impl RemoteAPIResource<APICredential> for GitCredential {
                 .flat_map(|m| m.get("personal_access_token").map(Clone::clone))
                 .flat_map(|buf| std::str::from_utf8(&buf.0).ok().map(ToString::to_string))
                 .next()
-                .ok_or(DatabricksKubeError::SecretMissingError)?;
+                .ok_or(DatabricksKubeError::SecretMissingError(secret_name))?;
 
             default_api::update_git_credential(
                 &config,

--- a/databricks-kube/src/crds/git_credential.rs
+++ b/databricks-kube/src/crds/git_credential.rs
@@ -103,9 +103,7 @@ impl RemoteAPIResource<APICredential> for GitCredential {
             self.spec()
                 .credential
                 .credential_id
-                .ok_or(DatabricksKubeError::ControllerError(
-                    "Cannot fetch remote resource when credential_id is undefined".to_string(),
-                ));
+                .ok_or(DatabricksKubeError::IDUnsetError);
 
         try_stream! {
             let config = APICredential::get_rest_config(context.clone()).await.unwrap();

--- a/databricks-kube/src/crds/git_credential.rs
+++ b/databricks-kube/src/crds/git_credential.rs
@@ -99,11 +99,11 @@ impl RemoteAPIResource<APICredential> for GitCredential {
         &self,
         context: Arc<Context>,
     ) -> Pin<Box<dyn Stream<Item = Result<APICredential, DatabricksKubeError>> + Send>> {
-        let credential_id =
-            self.spec()
-                .credential
-                .credential_id
-                .ok_or(DatabricksKubeError::IDUnsetError);
+        let credential_id = self
+            .spec()
+            .credential
+            .credential_id
+            .ok_or(DatabricksKubeError::IDUnsetError);
 
         try_stream! {
             let config = APICredential::get_rest_config(context.clone()).await.unwrap();

--- a/databricks-kube/src/crds/repo.rs
+++ b/databricks-kube/src/crds/repo.rs
@@ -91,9 +91,7 @@ impl RemoteAPIResource<APIRepo> for Repo {
             .spec()
             .repository
             .id
-            .ok_or(DatabricksKubeError::ControllerError(
-                "Cannot fetch remote resource when repository_id is undefined".to_string(),
-            ));
+            .ok_or(DatabricksKubeError::IDUnsetError);
 
         try_stream! {
             let config = APIRepo::get_rest_config(context.clone()).await.unwrap();

--- a/databricks-kube/src/crds/repo.rs
+++ b/databricks-kube/src/crds/repo.rs
@@ -91,8 +91,8 @@ impl RemoteAPIResource<APIRepo> for Repo {
             .spec()
             .repository
             .id
-            .ok_or(DatabricksKubeError::APIError(
-                "Remote resource cannot exist".to_string(),
+            .ok_or(DatabricksKubeError::ControllerError(
+                "Cannot fetch remote resource when repository_id is undefined".to_string(),
             ));
 
         try_stream! {

--- a/databricks-kube/src/error.rs
+++ b/databricks-kube/src/error.rs
@@ -1,44 +1,90 @@
-use std::error::Error;
+use databricks_rust_jobs::models::Job;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, to_value};
+use std::any::Any;
 use std::fmt::{Debug, Display};
+use std::sync::Arc;
+use thiserror::Error;
 
-use crate::context::CONFIGMAP_NAME;
-
-use databricks_rust_git_credentials::apis::Error as GitCredentialAPIError;
-use databricks_rust_jobs::apis::Error as JobsAPIError;
-use databricks_rust_repos::apis::Error as ReposAPIError;
+use databricks_rust_git_credentials::apis::{
+    Error as GitCredentialAPIError, ResponseContent as GitCredentialsResponseContent,
+};
+use databricks_rust_jobs::apis::{Error as JobsAPIError, ResponseContent as JobsResponseContent};
+use databricks_rust_repos::apis::{
+    Error as ReposAPIError, ResponseContent as ReposResponseContent,
+};
 use kube::runtime::finalizer::Error as KubeFinalizerError;
 
 impl<T> From<JobsAPIError<T>> for DatabricksKubeError
 where
-    T: Debug,
+    T: Debug + Serialize + 'static,
 {
     fn from(e: JobsAPIError<T>) -> Self {
-        Self::APIError(format!("{:?}", e))
+        match e {
+            JobsAPIError::ResponseError(JobsResponseContent {
+                status,
+                content,
+                entity,
+            }) => Self::APIError(OpenAPIError::ResponseError(SerializableResponseContent {
+                status,
+                content,
+                entity: entity.and_then(|e| to_value(e).ok()),
+            })),
+            JobsAPIError::Io(e) => Self::APIError(OpenAPIError::Io(e)),
+            JobsAPIError::Serde(e) => Self::APIError(OpenAPIError::Serde(e)),
+            JobsAPIError::Reqwest(e) => Self::APIError(OpenAPIError::Reqwest(e)),
+        }
     }
 }
 
 impl<T> From<GitCredentialAPIError<T>> for DatabricksKubeError
 where
-    T: Debug,
+    T: Debug + Serialize + 'static,
 {
     fn from(e: GitCredentialAPIError<T>) -> Self {
-        Self::APIError(format!("{:?}", e))
+        match e {
+            GitCredentialAPIError::ResponseError(GitCredentialsResponseContent {
+                status,
+                content,
+                entity,
+            }) => Self::APIError(OpenAPIError::ResponseError(SerializableResponseContent {
+                status,
+                content,
+                entity: entity.and_then(|e| to_value(e).ok()),
+            })),
+            GitCredentialAPIError::Io(e) => Self::APIError(OpenAPIError::Io(e)),
+            GitCredentialAPIError::Serde(e) => Self::APIError(OpenAPIError::Serde(e)),
+            GitCredentialAPIError::Reqwest(e) => Self::APIError(OpenAPIError::Reqwest(e)),
+        }
     }
 }
 
 impl<T> From<ReposAPIError<T>> for DatabricksKubeError
 where
-    T: Debug,
+    T: Debug + Serialize + 'static,
 {
     fn from(e: ReposAPIError<T>) -> Self {
-        Self::APIError(format!("{:?}", e))
+        match e {
+            ReposAPIError::ResponseError(ReposResponseContent {
+                status,
+                content,
+                entity,
+            }) => Self::APIError(OpenAPIError::ResponseError(SerializableResponseContent {
+                status,
+                content,
+                entity: entity.and_then(|e| to_value(e).ok()),
+            })),
+            ReposAPIError::Io(e) => Self::APIError(OpenAPIError::Io(e)),
+            ReposAPIError::Serde(e) => Self::APIError(OpenAPIError::Serde(e)),
+            ReposAPIError::Reqwest(e) => Self::APIError(OpenAPIError::Reqwest(e)),
+        }
     }
 }
 
 impl<T> From<KubeFinalizerError<T>> for DatabricksKubeError
 where
     T: Debug,
-    T: Error,
+    T: std::error::Error,
 {
     fn from(e: KubeFinalizerError<T>) -> Self {
         Self::FinalizerError(format!("{:?}", e))
@@ -46,51 +92,67 @@ where
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
-pub enum DatabricksKubeError {
-    APIError(String),
-    ConfigMapMissingError,
-    ControllerError(String),
-    CredentialsError,
-    CRDMissingError(String),
-    SecretMissingError,
-    Shutdown(String),
-    ResourceUpdateError(String),
-    ResourceStatusError(String),
-    FinalizerError(String),
+pub struct SerializableResponseContent {
+    pub status: reqwest::StatusCode,
+    pub content: String,
+    pub entity: Option<serde_json::Value>,
 }
 
-impl Display for DatabricksKubeError {
+#[derive(Error, Debug)]
+pub enum OpenAPIError {
+    Reqwest(#[from] reqwest::Error),
+    Serde(#[from] serde_json::Error),
+    Io(#[from] std::io::Error),
+    ResponseError(SerializableResponseContent),
+}
+
+impl Display for OpenAPIError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let msg = match self {
-            DatabricksKubeError::APIError(err )=> format!(
-                "Error calling Databricks API:\n{}",
-                err
-            ),
-            DatabricksKubeError::ControllerError(s) => format!(
-                "Controller reconciliation failed:\n{}",
-                s
-            ),
-            DatabricksKubeError::ConfigMapMissingError => format!(
-                "Timed out while waiting for config map: {}",
-                *CONFIGMAP_NAME
-            ),
-            DatabricksKubeError::CredentialsError => "Unable to get credentials".to_owned(),
-            DatabricksKubeError::CRDMissingError(crd) => format!(
-                "Timed out while waiting for CRD: {}\n\nGet all CRDs by running:\ncargo run --bin crd_gen",
-                crd
-            ),
-            DatabricksKubeError::Shutdown(s) => format!(
-                "Shutdown requested, exit: {}",
-                s
-            ),
-            DatabricksKubeError::SecretMissingError => "The secret referenced by this resource is missing".to_owned(),
-            DatabricksKubeError::ResourceUpdateError(s) => format!("Unable to update K8S Resource {}", s),
-            DatabricksKubeError::ResourceStatusError(s) => format!("Unable to get status {}", s),
-            DatabricksKubeError::FinalizerError(s) => format!("Finalizer failed {}", s),
-        };
-        write!(f, "{}", msg)
+        match self {
+            OpenAPIError::Reqwest(err) => Display::fmt(err, f),
+            OpenAPIError::Serde(err) => Display::fmt(err, f),
+            OpenAPIError::Io(err) => Display::fmt(err, f),
+            OpenAPIError::ResponseError(SerializableResponseContent {
+                status,
+                content,
+                entity,
+            }) => write!(f, "API response error: {} {} {:?}", status, content, entity),
+        }
     }
 }
 
-impl Error for DatabricksKubeError {}
+#[derive(Error, Debug)]
+#[allow(dead_code)]
+pub enum DatabricksKubeError {
+    #[error("Error calling Databricks API: {0}")]
+    APIError(#[from] OpenAPIError),
+
+    #[error("Timed out waiting for config map {0}")]
+    ConfigMapMissingError(String),
+
+    #[error("Controller reconciliation failed")]
+    ControllerError(String),
+
+    #[error("Timed out waiting for credentials")]
+    CredentialsError,
+
+    #[error(
+        "Timed out while waiting for CRD: {0}\n\nGet all CRDs by running:\ncargo run --bin crd_gen"
+    )]
+    CRDMissingError(String),
+
+    #[error("Secret {0} is missing")]
+    SecretMissingError(String),
+
+    #[error("Shutdown requested: {0}")]
+    Shutdown(String),
+
+    #[error("Unable to update resource for: {0}")]
+    ResourceUpdateError(String),
+
+    #[error("Unable to get resource status for: {0}")]
+    ResourceStatusError(String),
+
+    #[error("Finalizer error: {0}")]
+    FinalizerError(String),
+}

--- a/databricks-kube/src/error.rs
+++ b/databricks-kube/src/error.rs
@@ -1,9 +1,6 @@
-use databricks_rust_jobs::models::Job;
-use serde::{Deserialize, Serialize};
-use serde_json::{json, to_value};
-use std::any::Any;
+use serde::Serialize;
+use serde_json::to_value;
 use std::fmt::{Debug, Display};
-use std::sync::Arc;
 use thiserror::Error;
 
 use databricks_rust_git_credentials::apis::{
@@ -141,11 +138,11 @@ pub enum DatabricksKubeError {
     )]
     CRDMissingError(String),
 
-    #[error("Secret {0} is missing")]
-    SecretMissingError(String),
+    #[error("Finalizer error: {0}")]
+    FinalizerError(String),
 
-    #[error("Shutdown requested: {0}")]
-    Shutdown(String),
+    #[error("The resource ID is unset")]
+    IDUnsetError,
 
     #[error("Unable to update resource for: {0}")]
     ResourceUpdateError(String),
@@ -153,6 +150,9 @@ pub enum DatabricksKubeError {
     #[error("Unable to get resource status for: {0}")]
     ResourceStatusError(String),
 
-    #[error("Finalizer error: {0}")]
-    FinalizerError(String),
+    #[error("Secret {0} is missing")]
+    SecretMissingError(String),
+
+    #[error("Shutdown requested: {0}")]
+    Shutdown(String),
 }

--- a/databricks-kube/src/traits/remote_api_resource.rs
+++ b/databricks-kube/src/traits/remote_api_resource.rs
@@ -15,6 +15,7 @@ use kube::{
     Api, CustomResourceExt, Resource, ResourceExt,
 };
 
+use databricks_rust_jobs::apis::Error::Reqwest;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[allow(dead_code)]
@@ -44,134 +45,96 @@ where
 {
     let mut resource = resource;
     let kube_api = Api::<TCRDType>::default_namespaced(context.client.clone());
-    let latest_remote = resource.remote_get(context.clone()).next().await.unwrap();
-
-    let op_config = context.clone().get_operator_config();
-    let mut requeue_interval_sec = 300;
-
-    if op_config.is_some() {
-        requeue_interval_sec = op_config.unwrap().default_requeue_interval.unwrap();
-    }
-
-    // todo: enum
-    let owner = resource
-        .annotations()
-        .get("databricks-operator/owner")
-        .map(Clone::clone)
-        .unwrap_or("operator".to_string());
-
-    // Create if owned
-    if (owner == "operator") && latest_remote.is_err() {
-        log::info!(
-            "Resource {} {} is missing in Databricks, creating",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked()
-        );
-
-        let created = resource
-            .remote_create(context.clone())
-            .next()
-            .await
-            .unwrap()?;
-
-        log::info!(
-            "Created {} {} in Databricks",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked()
-        );
-
-        kube_api
-            .replace(&resource.name_unchecked(), &PostParams::default(), &created)
-            .await
-            .map_err(|e| DatabricksKubeError::ResourceUpdateError(e.to_string()))?;
-
-        log::info!(
-            "Updated {} {} in K8S",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked()
-        );
-
-        return Ok(Action::requeue(Duration::from_secs(requeue_interval_sec)));
-    }
-
-    let latest_remote = latest_remote?;
     let kube_as_api: TAPIType = resource.as_ref().clone().into();
 
-    if latest_remote != kube_as_api {
-        log::info!(
-            "Resource {} {} drifted!\nDiff (remote, kube):\n{}",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked(),
-            assert_json_matches_no_panic(
-                &latest_remote,
-                &kube_as_api,
-                assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict)
-            )
-            .unwrap_err()
-        );
+    let latest_remote = resource.remote_get(context.clone()).next().await.unwrap();
+    let requeue_secs = context
+        .as_ref()
+        .get_operator_config()
+        .and_then(|c| c.default_requeue_interval)
+        .unwrap_or(300);
+
+    match latest_remote {
+        Err(DatabricksKubeError::APIError(oae)) => {
+            log::info!("open api error! {}", oae);
+
+            log::info!(
+                "Resource {} {} is missing in Databricks, creating",
+                TCRDType::api_resource().kind,
+                resource.name_unchecked()
+            );
+
+            let created = resource
+                .remote_create(context.clone())
+                .next()
+                .await
+                .unwrap()?;
+
+            log::info!(
+                "Created {} {} in Databricks",
+                TCRDType::api_resource().kind,
+                resource.name_unchecked()
+            );
+
+            kube_api
+                .replace(&resource.name_unchecked(), &PostParams::default(), &created)
+                .await
+                .map_err(|e| DatabricksKubeError::ResourceUpdateError(e.to_string()))?;
+
+            log::info!(
+                "Updated {} {} in K8S",
+                TCRDType::api_resource().kind,
+                resource.name_unchecked()
+            );
+        }
+        Err(e) => {
+            panic!("rip")
+        }
+        Ok(remote) => {
+            if remote != kube_as_api {
+                log::info!(
+                    "Resource {} {} drifted!\nDiff (remote, kube):\n{}",
+                    TCRDType::api_resource().kind,
+                    resource.name_unchecked(),
+                    assert_json_matches_no_panic(
+                        &remote,
+                        &kube_as_api,
+                        assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict)
+                    )
+                    .unwrap_err()
+                );
+
+                log::info!(
+                    "Resource {} {} reconciling drift...",
+                    TCRDType::api_resource().kind,
+                    resource.name_unchecked()
+                );
+
+                let updated = resource
+                    .remote_update(context.clone())
+                    .next()
+                    .await
+                    .unwrap()?;
+
+                let replaced = kube_api
+                    .replace(&resource.name_unchecked(), &PostParams::default(), &updated)
+                    .await
+                    .map_err(|e| DatabricksKubeError::ResourceUpdateError(e.to_string()))?;
+
+                resource = replaced.into();
+
+                log::info!(
+                    "Updated {} {} in K8S",
+                    TCRDType::api_resource().kind,
+                    resource.name_unchecked()
+                );
+            }
+        }
     }
 
-    // Push to API if operator owned, or let user know
-    if (latest_remote != kube_as_api) && (owner == "operator") {
-        log::info!(
-            "Resource {} {} is owned by databricks-kube-operator, reconciling drift...",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked()
-        );
+    resource.every_reconcile_owned(context.clone()).await?;
 
-        let updated = resource
-            .remote_update(context.clone())
-            .next()
-            .await
-            .unwrap()?;
-
-        let replaced = kube_api
-            .replace(&resource.name_unchecked(), &PostParams::default(), &updated)
-            .await
-            .map_err(|e| DatabricksKubeError::ResourceUpdateError(e.to_string()))?;
-
-        resource = replaced.into();
-
-        log::info!(
-            "Updated {} {} in K8S",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked()
-        );
-    } else if latest_remote != kube_as_api {
-        log::info!(
-            "Resource {} {} is not owned by databricks-kube-operator, updating Kubernetes object.\nTo push updates to Databricks, ensure databricks-operator/owner: operator",
-            TCRDType::api_resource().kind,
-            resource.name_unchecked()
-        );
-
-        let mut latest_as_kube: TCRDType = latest_remote.into();
-        latest_as_kube
-            .annotations_mut()
-            .extend(resource.annotations().clone());
-        latest_as_kube
-            .labels_mut()
-            .extend(resource.labels().clone());
-        latest_as_kube
-            .meta_mut()
-            .merge_from(resource.meta().clone());
-
-        let replaced = kube_api
-            .replace(
-                &resource.name_unchecked(),
-                &PostParams::default(),
-                &latest_as_kube,
-            )
-            .await
-            .map_err(|e| DatabricksKubeError::ResourceUpdateError(e.to_string()))?;
-
-        resource = replaced.into();
-    }
-
-    if owner == "operator" {
-        resource.every_reconcile_owned(context.clone()).await?;
-    }
-
-    Ok(Action::requeue(Duration::from_secs(requeue_interval_sec)))
+    Ok(Action::requeue(Duration::from_secs(requeue_secs)))
 }
 
 #[allow(dead_code)]

--- a/databricks-kube/src/util.rs
+++ b/databricks-kube/src/util.rs
@@ -145,7 +145,9 @@ pub async fn ensure_api_secret(
         .flatten()
         .last()
         .flatten()
-        .ok_or(DatabricksKubeError::ConfigMapMissingError)?;
+        .ok_or(DatabricksKubeError::ConfigMapMissingError(
+            CONFIGMAP_NAME.clone(),
+        ))?;
 
     log::info!("Found API secret");
 
@@ -182,7 +184,9 @@ pub async fn ensure_configmap(cm_api: Api<ConfigMap>) -> Result<ConfigMap, Datab
         .flatten()
         .last()
         .flatten()
-        .ok_or(DatabricksKubeError::ConfigMapMissingError)?;
+        .ok_or(DatabricksKubeError::ConfigMapMissingError(
+            CONFIGMAP_NAME.clone(),
+        ))?;
 
     log::info!("Found config map");
 

--- a/databricks-kube/tests/remote_api_resource_test.rs
+++ b/databricks-kube/tests/remote_api_resource_test.rs
@@ -8,7 +8,6 @@ use common::mock_k8s::{
     mock_list_fake_resource,
 };
 
-use databricks_kube::error::{SerializableResponseContent, OpenAPIError};
 use databricks_kube::{
     context::Context, error::DatabricksKubeError, traits::remote_api_resource::RemoteAPIResource,
 };
@@ -16,7 +15,7 @@ use databricks_kube::{
 use async_stream::try_stream;
 use flurry::HashMap;
 use futures::{Future, FutureExt, Stream, StreamExt};
-use hyper::{Body, StatusCode};
+use hyper::Body;
 
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;

--- a/databricks-kube/tests/remote_api_resource_test.rs
+++ b/databricks-kube/tests/remote_api_resource_test.rs
@@ -59,7 +59,7 @@ impl RemoteAPIResource<FakeAPIResource> for FakeResource {
         .boxed()
     }
 
-    fn every_reconcile_owned(
+    fn every_reconcile(
         &self,
         _context: Arc<Context>,
     ) -> Pin<Box<dyn futures::Future<Output = Result<(), DatabricksKubeError>> + Send>> {


### PR DESCRIPTION
Whenever the Databricks API was unavailable, the operator did not differentiate between different kinds of failures (e.g. HTTP client error vs IO errors vs...), so it would attempt to recreate a resource that may have already existed. Due to each group of endpoints having its own SDK crate (i.e. for each OpenAPI source file), it was difficult to make a _single_ API error type to allow us to destructure e.g. IO errors for jobs the same way we would for gitcredentials or repos.

This changeset:

- Redefines `DatabricksKubeError` using [thiserror](https://crates.io/crates/thiserror) with clearer messages
- All client errors from all SDK crates are now represented as `OpenAPIError`, allowing operator code to use a single type for any arbitrary API client issue, so we can e.g. destructure the REST or IO errors inside.
  - `Error<T>` as generated by openapi-rust-generator is generic over `T` where T is the DTO type. To get around having a generic error, the glue in our refactored `From` traits leverages `Serializable` to present entity as `serde_json::Value`
    - Easy for error code to pull a field out of the value, or coerce it back to the original type (since we know what that is as the caller)
- Updated documentation and removed last-of cruft having to do with "API owned resources"