### PR TITLE
Bugfix: secret not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "databricks_kube"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "assert-json-diff",
  "async-stream",

--- a/databricks-kube/Cargo.toml
+++ b/databricks-kube/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/crdgen.rs"
 [package]
 name = "databricks_kube"
 default-run = "databricks_kube"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/databricks-kube/src/main.rs
+++ b/databricks-kube/src/main.rs
@@ -65,10 +65,11 @@ async fn main() -> Result<(), DatabricksKubeError> {
     log::info!("boot! (build: {})", git_version!());
 
     let kube_client = Client::try_default().await.expect("Must create client");
+    log::info!("Client namespace {}", kube_client.default_namespace());
 
     let cm_api = Api::<ConfigMap>::default_namespaced(kube_client.clone());
     let crd_api = Api::<CustomResourceDefinition>::all(kube_client.clone());
-    let secret_api = Api::<Secret>::all(kube_client.clone());
+    let secret_api = Api::<Secret>::default_namespaced(kube_client.clone());
 
     ensure_crd("databricksjobs.com.dstancu.databricks", crd_api.clone()).await?;
     ensure_crd("gitcredentials.com.dstancu.databricks", crd_api.clone()).await?;

--- a/databricks-kube/src/util.rs
+++ b/databricks-kube/src/util.rs
@@ -145,9 +145,7 @@ pub async fn ensure_api_secret(
         .flatten()
         .last()
         .flatten()
-        .ok_or(DatabricksKubeError::ConfigMapMissingError(
-            CONFIGMAP_NAME.clone(),
-        ))?;
+        .ok_or(DatabricksKubeError::SecretMissingError(api_secret_name))?;
 
     log::info!("Found API secret");
 


### PR DESCRIPTION
The secret client was not instantiated with `::default_namespaced`. Since the secret name is unique, trying to read across all NS succeeded. But not in the case the name is shadowed in another namespace. 