### PR TITLE
support for multi-arch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --test-threads=1
+      - uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "test"
+          toolchain: stable
+          args: "--test-threads=1"
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,22 +11,30 @@ jobs:
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}
   test:
-    name: Build, test (x86)
+    name: Test (x86)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --test-threads=1
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    strategy: 
+      matrix:
+        target: [ aarch64-unknown-linux-gnu, x86_64-unknown-linux-gnu ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
         with:
-          command: test
-          args: -- --test-threads=1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
+          command: "build"
+          target: ${{ matrix.target }}
+          toolchain: stable
+          args: "--locked --release --all-features"
+          strip: true
       - uses: actions/upload-artifact@v4
         with:
           name: crd_gen
@@ -34,11 +42,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: databricks_kube
-          path: target/release/databricks_kube
-  publish_image:
+          path: target/release/databricks_kube 
+  publish:
     name: Docker
     runs-on: ubuntu-latest
-    needs: test
+    needs: build
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -68,5 +72,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "databricks_kube"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "assert-json-diff",
  "async-stream",

--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.6.1
+appVersion: 0.6.2
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.6.1
+version: 0.6.2
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/charts/databricks-kube-operator/values.yaml
+++ b/charts/databricks-kube-operator/values.yaml
@@ -9,6 +9,5 @@ image:
 podAnnotations: {}
 nodeSelector:
   kubernetes.io/os: linux
-  kubernetes.io/arch: amd64
 resources: {}
 affinity: {}

--- a/databricks-kube/Cargo.toml
+++ b/databricks-kube/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/crdgen.rs"
 [package]
 name = "databricks_kube"
 default-run = "databricks_kube"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
* https://github.com/actions-rs is now unmaintained and readonly as of 10/13, and uses deprecated node 12
* move away from `actions-rs`  to https://github.com/houseabsolute/actions-rust-cross
* break out test and build into separate jobs/stages
* build docker for both `linux/amd64` and `linux/arm64`
* update `databricks-kube` version
* remove hard coded architecture in helm chart `nodeSelector`
* bump helm chart version

Signed-off-by: smcavallo <smcavallo@hotmail.com>