### PR TITLE
Adds flexibility to rbac components

### DIFF
--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.8.0
+appVersion: 0.7.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
 version: 0.8.0

--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.7.0
+appVersion: 0.8.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.7.0
+version: 0.8.0
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/charts/databricks-kube-operator/templates/rbac.yaml
+++ b/charts/databricks-kube-operator/templates/rbac.yaml
@@ -1,14 +1,15 @@
+{{- $svcAccount := include "databricks-kube-operator.serviceAccountName" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: databricks-kube-operator
+  name: "{{ $svcAccount }}"
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: databricks-kube-operator
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -37,13 +38,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: databricks-kube-operator
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
-  name: databricks-kube-operator
+  name: "{{ $svcAccount }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: databricks-kube-operator
+  name: {{ .Release.Name }}

--- a/charts/databricks-kube-operator/templates/sts.yaml
+++ b/charts/databricks-kube-operator/templates/sts.yaml
@@ -1,3 +1,5 @@
+{{- $svcAccount := include "databricks-kube-operator.serviceAccountName" . }}
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -19,7 +21,7 @@ spec:
       labels:
         app: {{ template "databricks-kube-operator.name" . }}
     spec:
-      serviceAccountName: databricks-kube-operator
+      serviceAccountName: "{{ $svcAccount }}"
       terminationGracePeriodSeconds: 10
       containers:
       - name: dko

--- a/charts/databricks-kube-operator/values.yaml
+++ b/charts/databricks-kube-operator/values.yaml
@@ -12,3 +12,7 @@ nodeSelector:
   kubernetes.io/arch: amd64
 resources: {}
 affinity: {}
+
+serviceAccount:
+  create: true
+  name: "databricks-kube-operator"


### PR DESCRIPTION
Context:
- When instantiating multiple instances of the databricks operator in a single cluster, collisions between the service account, cluster role, and cluster role binding would occur.

This PR:
- Allows for the service account name to be overridden
- Sets the CR/CRB to `.Release.Name`
- Associates the new names