### PR TITLE
Replaces helper based serviceAccount reference with explicit value

### DIFF
--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.7.0
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.8.1
+version: 0.8.2
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/charts/databricks-kube-operator/templates/rbac.yaml
+++ b/charts/databricks-kube-operator/templates/rbac.yaml
@@ -1,10 +1,9 @@
-{{- $svcAccount := include "databricks-kube-operator.serviceAccountName" . }}
 {{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ $svcAccount }}"
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
@@ -45,7 +44,7 @@ metadata:
 subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
-  name: "{{ $svcAccount }}"
+  name: {{ .Values.serviceAccount.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/databricks-kube-operator/templates/sts.yaml
+++ b/charts/databricks-kube-operator/templates/sts.yaml
@@ -1,4 +1,3 @@
-{{- $svcAccount := include "databricks-kube-operator.serviceAccountName" . }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -21,7 +20,7 @@ spec:
       labels:
         app: {{ template "databricks-kube-operator.name" . }}
     spec:
-      serviceAccountName: "{{ $svcAccount }}"
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: 10
       containers:
       - name: dko


### PR DESCRIPTION
This PR addresses the difference in the way `helm template` vs `helm install` works when layering attributes in the helper functions. Previously, the serviceAccount would always render as the default set in this operator where as now it will accept the override.