### PR TITLE
Bugfix: `InitScriptInfo` schema does not match REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "databricks_kube"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "assert-json-diff",
  "async-stream",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "databricks_rust_jobs"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "reqwest 0.12.5",
  "schemars",

--- a/charts/databricks-kube-operator/Chart.yaml
+++ b/charts/databricks-kube-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.8.2
+appVersion: 0.8.3
 name: databricks-kube-operator
 description: A kube-rs operator for managing Databricks API resources
-version: 0.9.3
+version: 0.9.4
 
 home: https://github.com/mach-kernel/databricks-kube-operator
 sources:

--- a/charts/databricks-kube-operator/templates/crds.yaml
+++ b/charts/databricks-kube-operator/templates/crds.yaml
@@ -271,6 +271,7 @@ spec:
                                   - LEGACY_TABLE_ACL
                                   - LEGACY_PASSTHROUGH
                                   - LEGACY_SINGLE_USER
+                                  - LEGACY_SINGLE_USER_STANDARD
                                   nullable: true
                                   type: string
                                 docker_image:
@@ -313,7 +314,23 @@ spec:
                                   description: The configuration for storing init scripts. Any number of scripts can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `<destination>/<cluster-id>/init_scripts`.
                                   items:
                                     properties:
-                                      S3:
+                                      dbfs:
+                                        nullable: true
+                                        properties:
+                                          destination:
+                                            description: 'DBFS destination. Example: `dbfs:/my/path`'
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                      file:
+                                        nullable: true
+                                        properties:
+                                          destination:
+                                            description: 'File destination. Example: `file:/my/file.sh`'
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                      s3:
                                         nullable: true
                                         properties:
                                           canned_acl:
@@ -342,22 +359,6 @@ spec:
                                             type: string
                                           region:
                                             description: 'S3 region. For example: `us-west-2`. Either region or endpoint must be set. If both are set, endpoint is used.'
-                                            nullable: true
-                                            type: string
-                                        type: object
-                                      dbfs:
-                                        nullable: true
-                                        properties:
-                                          destination:
-                                            description: 'DBFS destination. Example: `dbfs:/my/path`'
-                                            nullable: true
-                                            type: string
-                                        type: object
-                                      file:
-                                        nullable: true
-                                        properties:
-                                          destination:
-                                            description: 'File destination. Example: `file:/my/file.sh`'
                                             nullable: true
                                             type: string
                                         type: object
@@ -748,6 +749,7 @@ spec:
                                   - LEGACY_TABLE_ACL
                                   - LEGACY_PASSTHROUGH
                                   - LEGACY_SINGLE_USER
+                                  - LEGACY_SINGLE_USER_STANDARD
                                   nullable: true
                                   type: string
                                 docker_image:
@@ -790,7 +792,23 @@ spec:
                                   description: The configuration for storing init scripts. Any number of scripts can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `<destination>/<cluster-id>/init_scripts`.
                                   items:
                                     properties:
-                                      S3:
+                                      dbfs:
+                                        nullable: true
+                                        properties:
+                                          destination:
+                                            description: 'DBFS destination. Example: `dbfs:/my/path`'
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                      file:
+                                        nullable: true
+                                        properties:
+                                          destination:
+                                            description: 'File destination. Example: `file:/my/file.sh`'
+                                            nullable: true
+                                            type: string
+                                        type: object
+                                      s3:
                                         nullable: true
                                         properties:
                                           canned_acl:
@@ -819,22 +837,6 @@ spec:
                                             type: string
                                           region:
                                             description: 'S3 region. For example: `us-west-2`. Either region or endpoint must be set. If both are set, endpoint is used.'
-                                            nullable: true
-                                            type: string
-                                        type: object
-                                      dbfs:
-                                        nullable: true
-                                        properties:
-                                          destination:
-                                            description: 'DBFS destination. Example: `dbfs:/my/path`'
-                                            nullable: true
-                                            type: string
-                                        type: object
-                                      file:
-                                        nullable: true
-                                        properties:
-                                          destination:
-                                            description: 'File destination. Example: `file:/my/file.sh`'
                                             nullable: true
                                             type: string
                                         type: object

--- a/databricks-kube/Cargo.toml
+++ b/databricks-kube/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/crdgen.rs"
 [package]
 name = "databricks_kube"
 default-run = "databricks_kube"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 [dependencies]

--- a/databricks-rust-jobs/Cargo.toml
+++ b/databricks-rust-jobs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databricks_rust_jobs"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["OpenAPI Generator team and contributors"]
 description = "The Jobs API allows you to create, edit, and delete jobs. You should never hard code secrets or store them in plain text. Use the [Secrets API](https://docs.databricks.com/dev-tools/api/latest/secrets.html) to manage secrets in the [Databricks CLI](https://docs.databricks.com/dev-tools/cli/index.html). Use the [Secrets utility](https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-secrets) to reference secrets in notebooks and jobs."
 # Override this license by providing a License Object in the OpenAPI.

--- a/databricks-rust-jobs/src/models/init_script_info.rs
+++ b/databricks-rust-jobs/src/models/init_script_info.rs
@@ -18,7 +18,7 @@ pub struct InitScriptInfo {
     pub dbfs: Option<Box<crate::models::DbfsStorageInfo>>,
     #[serde(rename = "file", skip_serializing_if = "Option::is_none")]
     pub file: Option<Box<crate::models::FileStorageInfo>>,
-    #[serde(rename = "S3", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "s3", skip_serializing_if = "Option::is_none")]
     pub s3: Option<Box<crate::models::S3StorageInfo>>,
 }
 

--- a/openapi/jobs-2.1-aws.yaml
+++ b/openapi/jobs-2.1-aws.yaml
@@ -3759,7 +3759,7 @@ components:
             File location of init script. Destination must be provided. For
             example, `{ "file" : { "destination" : "file:/my/local/file.sh" } }`
           $ref: '#/components/schemas/FileStorageInfo'
-        S3:
+        s3:
           description: >-
             S3 location of init script. Destination and either region or
             endpoint must be provided. For example, `{ "s3": { "destination" :


### PR DESCRIPTION
Fixes the casing of `S3` to `s3` in order to match the Databricks API.